### PR TITLE
Added Git-Sync to sync this with staging repo

### DIFF
--- a/.github/workflows/staging-push.yml
+++ b/.github/workflows/staging-push.yml
@@ -1,0 +1,11 @@
+on:
+  push:
+    branches: [main]
+jobs:
+  - name: git-sync
+    uses: wei/git-sync@v3
+    with:
+      source_repo: MSCSHub/MSCSHub
+      source_branch: main
+      destination_repo: MSCSHub/MSCSHub-staging
+      destination_branch: main


### PR DESCRIPTION
This should make MSCSHub sync to MSCSHub-Staging whenever a mush to main happens. My long term goal is to setup an auto-deploy on that repo and point it to staging.mscshub.com with a staging database backend. That will allow us to have a true testing environment 